### PR TITLE
use slimmer docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Create release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           # create a draft release which needs manual approval
           draft: true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,14 @@
-FROM ghcr.io/rust-cross/rust-musl-cross:aarch64-musl AS aarch64-musl
+# Use the x86_64 and aarch64 musl images directly
+FROM ghcr.io/rust-cross/rust-musl-cross:x86_64-musl AS musl_x86_64
+FROM ghcr.io/rust-cross/rust-musl-cross:aarch64-musl AS musl_aarch64
 
-FROM ghcr.io/rust-cross/rust-musl-cross:x86_64-musl AS x86_64-musl
+# Use slimmer base image
+FROM rust:1.80.1-slim-bookworm AS build-base
 
-FROM rust:1.80.1-bookworm
-# prepopulate cargo index
-RUN cargo search --limit=1
-RUN apt update && apt upgrade -y
-RUN apt -y install \
+# Prepopulate cargo index and install dependencies
+RUN cargo search --limit=1 && \
+    apt update && apt upgrade -y && \
+    apt -y install --no-install-recommends \
     g++-x86-64-linux-gnu \
     g++-aarch64-linux-gnu \
     protobuf-compiler \
@@ -15,64 +17,69 @@ RUN apt -y install \
     cmake \
     llvm \
     liburing-dev \
-    ca-certificates
-RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+    ca-certificates \
+    git \
+    curl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install rustup components and global tools in a single layer
 RUN rustup target add \
     x86_64-unknown-linux-musl \
     aarch64-unknown-linux-musl \
     x86_64-unknown-linux-gnu \
-    aarch64-unknown-linux-gnu
-RUN rustup component add clippy rustfmt
-RUN cargo install cargo-chef@0.1.67 cargo-license@0.6.1
+    aarch64-unknown-linux-gnu && \
+    rustup component add clippy rustfmt && \
+    cargo install cargo-chef@0.1.67 cargo-license@0.6.1
 
-COPY --from=x86_64-musl "/usr/local/musl" /usr/local/musl-x86_64/
-COPY --from=aarch64-musl "/usr/local/musl" /usr/local/musl-aarch64/
-ENV PATH="${PATH}:/usr/local/musl-x86_64/bin:/usr/local/musl-aarch64/bin"
+# Install `just`
+RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
 
-# linker script forcing static compilation of libstdc++
-RUN echo 'GROUP ( libstdc++.a AS_NEEDED( -lgcc -lc -lm ) )' > $(readlink -f $(x86_64-unknown-linux-musl-g++ --print-file-name libstdc++.so))
-RUN echo 'GROUP ( libstdc++.a AS_NEEDED( -lgcc -lc -lm ) )' > $(readlink -f $(aarch64-unknown-linux-musl-g++ --print-file-name libstdc++.so))
-
+# Install `sccache` and `buf` in a single layer
 ARG TARGETARCH
 RUN arch=$(echo "$TARGETARCH" | sed s/arm64/aarch64/ | sed s/amd64/x86_64/) && \
     curl -LSfs https://github.com/mozilla/sccache/releases/download/v0.7.4/sccache-v0.7.4-${arch}-unknown-linux-musl.tar.gz -o sccache.tar.gz && \
     tar -xvf sccache.tar.gz && \
     rm sccache.tar.gz && \
     cp sccache-v0.7.4-${arch}-unknown-linux-musl/sccache /usr/bin/sccache && \
-    rm -rf sccache-v0.7.4-${arch}-unknown-linux-musl
-
-ENV SCCACHE_DIR=/usr/local/sccache
-
-RUN arch=$(echo "$TARGETARCH" | sed s/arm64/aarch64/ | sed s/amd64/x86_64/) && \
+    rm -rf sccache-v0.7.4-${arch}-unknown-linux-musl && \
     curl -sSL "https://github.com/bufbuild/buf/releases/download/v1.29.0/buf-Linux-${arch}" -o "/usr/bin/buf" && \
     chmod +x "/usr/bin/buf"
 
+# Copy musl from the prebuilt x86_64 and aarch64 images
+COPY --from=musl_x86_64 "/usr/local/musl" /usr/local/musl-x86_64/
+COPY --from=musl_aarch64 "/usr/local/musl" /usr/local/musl-aarch64/
+
+# Set environment variables for cross-compilation
+ENV PATH="${PATH}:/usr/local/musl-x86_64/bin:/usr/local/musl-aarch64/bin"
+ENV SCCACHE_DIR=/usr/local/sccache
+ENV RUSTC_WRAPPER="sccache"
+
+# x86_64 musl
 ENV CC_x86_64_unknown_linux_musl="sccache x86_64-unknown-linux-musl-gcc"
 ENV CXX_x86_64_unknown_linux_musl="sccache x86_64-unknown-linux-musl-g++"
 ENV AR_x86_64_unknown_linux_musl="x86_64-unknown-linux-musl-ar"
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="x86_64-unknown-linux-musl-gcc"
-ENV BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_linux_musl="--sysroot=/usr/x86_64-linux-musl"
 
+# aarch64 musl
 ENV CC_aarch64_unknown_linux_musl="sccache aarch64-unknown-linux-musl-gcc"
 ENV CXX_aarch64_unknown_linux_musl="sccache aarch64-unknown-linux-musl-g++"
-ENV AR_aarch64_unknown_linux_musl="aarch64-unknown-linux-musl-ar"
+ENV AR_aarch64_unknown-linux_musl="aarch64-unknown-linux-musl-ar"
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="aarch64-unknown-linux-musl-gcc"
-ENV BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_musl="--sysroot=/usr/aarch64-linux-musl"
 
+# x86_64 gnu
 ENV CC_x86_64_unknown_linux_gnu="sccache x86_64-linux-gnu-gcc"
 ENV CXX_x86_64_unknown_linux_gnu="sccache x86_64-linux-gnu-g++"
 ENV AR_x86_64_unknown_linux_gnu="x86_64-linux-gnu-ar"
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="x86_64-linux-gnu-gcc"
-ENV BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_linux_gnu="--sysroot=/usr/x86_64-linux-gnu"
 
+# aarch64 gnu
 ENV CC_aarch64_unknown_linux_gnu="sccache aarch64-linux-gnu-gcc"
 ENV CXX_aarch64_unknown_linux_gnu="sccache aarch64-linux-gnu-g++"
-ENV AR_aarch64_unknown_linux_gnu="aarch64-linux-gnu-ar"
+ENV AR_aarch64_unknown-linux-gnu="aarch64-linux-gnu-ar"
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-gcc"
-ENV BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_gnu="--sysroot=/usr/aarch64-linux-gnu"
 
-ENV RUSTC_WRAPPER="sccache"
-
+# Set up working directory
 WORKDIR /restate
+
 # Make git work if different owner runs commands
 RUN git config --global --add safe.directory /restate

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,6 @@
-# Use the x86_64 and aarch64 musl images directly
 FROM ghcr.io/rust-cross/rust-musl-cross:x86_64-musl AS musl_x86_64
 FROM ghcr.io/rust-cross/rust-musl-cross:aarch64-musl AS musl_aarch64
 
-# Use slimmer base image
 FROM rust:1.80.1-slim-bookworm AS build-base
 
 # Prepopulate cargo index and install dependencies
@@ -59,24 +57,28 @@ ENV CC_x86_64_unknown_linux_musl="sccache x86_64-unknown-linux-musl-gcc"
 ENV CXX_x86_64_unknown_linux_musl="sccache x86_64-unknown-linux-musl-g++"
 ENV AR_x86_64_unknown_linux_musl="x86_64-unknown-linux-musl-ar"
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="x86_64-unknown-linux-musl-gcc"
+ENV BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_linux_musl="--sysroot=/usr/x86_64-linux-musl"
 
 # aarch64 musl
 ENV CC_aarch64_unknown_linux_musl="sccache aarch64-unknown-linux-musl-gcc"
 ENV CXX_aarch64_unknown_linux_musl="sccache aarch64-unknown-linux-musl-g++"
-ENV AR_aarch64_unknown-linux_musl="aarch64-unknown-linux-musl-ar"
+ENV AR_aarch64_unknown_linux_musl="aarch64-unknown-linux-musl-ar"
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="aarch64-unknown-linux-musl-gcc"
+ENV BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_musl="--sysroot=/usr/aarch64-linux-musl"
 
 # x86_64 gnu
 ENV CC_x86_64_unknown_linux_gnu="sccache x86_64-linux-gnu-gcc"
 ENV CXX_x86_64_unknown_linux_gnu="sccache x86_64-linux-gnu-g++"
 ENV AR_x86_64_unknown_linux_gnu="x86_64-linux-gnu-ar"
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="x86_64-linux-gnu-gcc"
+ENV BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_linux_gnu="--sysroot=/usr/x86_64-linux-gnu"
 
 # aarch64 gnu
 ENV CC_aarch64_unknown_linux_gnu="sccache aarch64-linux-gnu-gcc"
 ENV CXX_aarch64_unknown_linux_gnu="sccache aarch64-linux-gnu-g++"
-ENV AR_aarch64_unknown-linux-gnu="aarch64-linux-gnu-ar"
+ENV AR_aarch64_unknown_linux_gnu="aarch64-linux-gnu-ar"
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-gcc"
+ENV BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_gnu="--sysroot=/usr/aarch64-linux-gnu"
 
 # Set up working directory
 WORKDIR /restate

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,6 +52,10 @@ ENV PATH="${PATH}:/usr/local/musl-x86_64/bin:/usr/local/musl-aarch64/bin"
 ENV SCCACHE_DIR=/usr/local/sccache
 ENV RUSTC_WRAPPER="sccache"
 
+# linker script forcing static compilation of libstdc++
+RUN echo 'GROUP ( libstdc++.a AS_NEEDED( -lgcc -lc -lm ) )' > $(readlink -f $(x86_64-unknown-linux-musl-g++ --print-file-name libstdc++.so))
+RUN echo 'GROUP ( libstdc++.a AS_NEEDED( -lgcc -lc -lm ) )' > $(readlink -f $(aarch64-unknown-linux-musl-g++ --print-file-name libstdc++.so))
+
 # x86_64 musl
 ENV CC_x86_64_unknown_linux_musl="sccache x86_64-unknown-linux-musl-gcc"
 ENV CXX_x86_64_unknown_linux_musl="sccache x86_64-unknown-linux-musl-g++"


### PR DESCRIPTION
improvements: 
Layer Reduction: Combined RUN commands where appropriate.
Smaller Base Image: Used bookworm-slim as the base to reduce image size.
Removed Unnecessary Packages: Used --no-install-recommends to install only necessary packages, avoiding bloated images.

might help a little bit in resolving https://github.com/restatedev/dev-tools/issues/7