### PR TITLE
Bump Rust image to 1.84.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN rustup target add \
     x86_64-unknown-linux-gnu \
     aarch64-unknown-linux-gnu && \
     rustup component add clippy rustfmt && \
-    cargo install cargo-chef@0.1.68 cargo-license@0.6.1 cargo-hakari@0.9.35
+    cargo install cargo-chef@0.1.71 cargo-license@0.6.1 cargo-hakari@0.9.35
 
 # Install `just`
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/rust-cross/rust-musl-cross:x86_64-musl AS musl_x86_64
 FROM ghcr.io/rust-cross/rust-musl-cross:aarch64-musl AS musl_aarch64
 
-FROM rust:1.82.0-slim-bookworm AS build-base
+FROM rust:1.84.1-slim-bookworm AS build-base
 
 # Prepopulate cargo index and install dependencies
 RUN cargo search --limit=1 && \


### PR DESCRIPTION
Tested locally against https://github.com/restatedev/restate/pull/2611:

```
❯ just --set arch x86_64 --set features metadata-api docker-debug
# podman builds do not work without --platform set, even though it claims to default to host arch
docker buildx build . --platform linux/amd64 --file docker/debug.Dockerfile --tag=localhost/restatedev/restate:chore.rust-1.84.43310a101 --progress='auto' --build-arg RESTATE_FEATURES=metadata-api --load
[+] Building 579.0s (22/22) FINISHED                                                                                                                                    docker:orbstack
 => [internal] load build definition from debug.Dockerfile                                                                                                                         0.0s
 => => transferring dockerfile: 2.66kB                                                                                                                                             0.0s
 => [internal] load metadata for localhost/restatedev/dev-tools:latest                                                                                                             0.0s
 => [internal] load metadata for docker.io/library/debian:bookworm-slim                                                                                                            1.0s
 => [internal] load .dockerignore                                                                                                                                                  0.0s
 => => transferring context: 140B                                                                                                                                                  0.0s
 => [internal] load build context                                                                                                                                                  1.0s
 => => transferring context: 1.76MB                                                                                                                                                1.0s
 => CACHED [runtime 1/9] FROM docker.io/library/debian:bookworm-slim@sha256:f70dc8d6a8b6a06824c92471a1a258030836b26b043881358b967bf73de7c5ab                                       0.0s
 => [planner 1/3] FROM localhost/restatedev/dev-tools:latest                                                                                                                       0.3s
 => [planner 2/3] COPY . .                                                                                                                                                         1.5s
 => [planner 3/3] RUN just chef-prepare                                                                                                                                            0.7s
 => [base 2/3] COPY --from=planner /restate/recipe.json recipe.json                                                                                                                0.0s
 => [base 3/3] COPY justfile justfile                                                                                                                                              0.0s
 => [builder 1/3] RUN just arch=amd64 libc=gnu features=metadata-api chef-cook --bins                                                                                            332.5s
 => [builder 2/3] COPY . .                                                                                                                                                         2.9s
 => [builder 3/3] RUN --mount=type=cache,target=/var/cache/sccache     just arch=amd64 libc=gnu features=metadata-api build --bins &&     just notice-file &&     mv target/$(j  205.7s
 => [runtime 2/9] COPY --from=builder /restate/target/restate-server /usr/local/bin                                                                                                0.1s
 => [runtime 3/9] COPY --from=builder /restate/target/restatectl /usr/local/bin                                                                                                    0.1s
 => [runtime 4/9] COPY --from=builder /restate/target/restate /usr/local/bin                                                                                                       0.1s
 => [runtime 5/9] COPY --from=builder /restate/NOTICE /NOTICE                                                                                                                      0.1s
 => [runtime 6/9] COPY --from=builder /restate/LICENSE /LICENSE                                                                                                                    0.0s
 => [runtime 7/9] COPY --from=builder /etc/ssl /etc/ssl                                                                                                                            0.1s
 => [runtime 8/9] RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*                                                                                    18.7s
 => exporting to image                                                                                                                                                             5.6s
 => => exporting layers                                                                                                                                                            5.6s
 => => writing image sha256:07137ab82c7f8675f1e3381b1835be3a9a5abce948a4a316b069dea23c28c88d                                                                                       0.0s
 => => naming to localhost/restatedev/restate:chore.rust-1.84.43310a101                                                                                                            0.0s

```