### PR TITLE
Upgrade toolchain to 1.90 + trixie

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/rust-cross/rust-musl-cross:x86_64-musl AS musl_x86_64
 FROM ghcr.io/rust-cross/rust-musl-cross:aarch64-musl AS musl_aarch64
 
-FROM rust:1.89.0-slim-bookworm AS build-base
+FROM rust:1.90.0-slim-trixie AS build-base
 
 # Prepopulate cargo index and install dependencies
 RUN cargo search --limit=1 && \


### PR DESCRIPTION
Upgrades the Rust toolchain to 1.90 and switches out the dev image to Debian 13 (the unqualified `rust` [1.90](https://github.com/rust-lang/docker-rust/blob/3aad80112be66bf796c202713029d7ba93dff7fa/stable/trixie/Dockerfile) tag now uses `trixie`). Tested with `restate` @ `ae06f21e` in both release and debug configurations.